### PR TITLE
Add tests for `partials.py` to achieve 100% test coverage

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/tests/test_partials.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/tests/test_partials.py
@@ -1,0 +1,46 @@
+import pytest
+from django_htmx.middleware import HtmxDetails
+
+from {{ cookiecutter.project_slug }}.partials import render_partial_for_target
+
+
+class TestRenderPartialForTarget:
+    @pytest.fixture
+    def mock_render(self, mocker):
+        return mocker.patch("{{ cookiecutter.project_slug }}.partials.render")
+
+    def test_target_matches(self, rf, mock_render):
+        request = rf.get("/", HTTP_HX_TARGET="target", HTTP_HX_REQUEST="true")
+        request.htmx = HtmxDetails(request)
+
+        render_partial_for_target(
+            request,
+            "template.html",
+            target="target",
+            partial="partial",
+        )
+        mock_render.assert_called_once_with(request, "template.html#partial", None)
+
+    def test_target_not_matches(self, rf, mock_render):
+        request = rf.get("/", HTTP_HX_TARGET="other", HTTP_HX_REQUEST="true")
+        request.htmx = HtmxDetails(request)
+
+        render_partial_for_target(
+            request,
+            "template.html",
+            target="target",
+            partial="partial",
+        )
+        mock_render.assert_called_once_with(request, "template.html", None)
+
+    def test_target_not_htmx(self, rf, mock_render):
+        request = rf.get("/")
+        request.htmx = HtmxDetails(request)
+
+        render_partial_for_target(
+            request,
+            "template.html",
+            target="target",
+            partial="partial",
+        )
+        mock_render.assert_called_once_with(request, "template.html", None)


### PR DESCRIPTION
This PR adds tests for the `partials.py` file to fix a coverage gap that caused the following error in the `unittests` job of the `checks.yml` GitHub workflow:
```
---------- coverage: platform linux, python 3.13.0-final-0 -----------
Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
project_name/__init__.py             0      0   100%
project_name/checks.py               8      0   100%
project_name/middleware.py          35      0   100%
project_name/partials.py             6      6     0%   1-21
project_name/templatetags.py        30      0   100%
project_name/users/__init__.py       0      0   100%
project_name/users/admin.py          5      0   100%
project_name/users/apps.py           4      0   100%
project_name/users/models.py         2      0   100%
project_name/views.py               40      0   100%
--------------------------------------------------------
TOTAL                        130      6    95%

FAIL Required test coverage of 100% not reached. Total coverage: 95.38%
```
The new `test_partials.py` file has been copied and adapted from your [radiofeed-app](https://github.com/danjac/radiofeed-app) project.

Before this change, `partials.py` had no test coverage (0%). With these tests, the project now meets the required 100% test coverage threshold.