### PR TITLE
Ensure `uv.lock` is created before syncronizing

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -30,6 +30,7 @@ jobs:
                     **/uv.lock
                     **/pyproject.toml
             - run: uv python install 3.13.0
+            - run: uv lock
             - run: uv sync --frozen --all-extras --no-install-project
             - run: uv run pyright
             - run: uv run python ./manage.py validate_templates


### PR DESCRIPTION
This PR adds a `uv lock` step after `uv python install` and before `uv sync` in the `unittests` job of the `checks.yml` GitHub workflow, resolving the following issue, which caused the workflow to fail:
```
Run uv sync --frozen --all-extras --no-install-project
Using CPython 3.13.0
Creating virtual environment at: .venv
error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
Error: Process completed with exit code 2.
```
By generating the `uv.lock` file before running `uv sync`, we ensure the dependencies are properly locked and the workflow can proceed without errors.